### PR TITLE
Simplifying how build works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ hadoop-connector/build
 hadoop-example/build
 pig-connector/build
 squeal/build
+.build.properties
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+hadoop-connector/build
+hadoop-example/build
+pig-connector/build
+squeal/build
+

--- a/build-common.xml
+++ b/build-common.xml
@@ -3,13 +3,16 @@
   <!--
   Common build file for properties or tasks that should be shared across sub-project build files.
   -->
+  
+  <property name="projectroot" value = "${basedir}/.."/>
+  <property file="${projectroot}/.build.properties"/>
 
   <!-- When making a versioned release, create a branch and change the build.version below -->
   <property name="build.version" value = "SNAPSHOT" />
 
   <!-- some common defaults -->
   <property name="hadoop-connector.jar"
-            value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica-${build.version}.jar" />
+            value = "${projectroot}/hadoop-connector/build/hadoop-connector/jar/hadoop-vertica-${build.version}.jar" />
 
   <!-- These require targets could be done better with a single macro -->
   <target name="requirehadoopdir">

--- a/build-common.xml
+++ b/build-common.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="common">
+  <!--
+  Common build file for properties or tasks that should be shared across sub-project build files.
+  -->
+
+  <!-- When making a versioned release, create a branch and change the build.version below -->
+  <property name="build.version" value = "SNAPSHOT" />
+
+  <!-- some common defaults -->
+  <property name="hadoop-connector.jar"
+            value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica-${build.version}.jar" />
+
+  <!-- These require targets could be done better with a single macro -->
+  <target name="requirehadoopdir">
+    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a value">
+      <condition>
+          <or>
+            <equals arg1="${hadoop.dir}" arg2=""/>
+            <not><isset property="hadoop.dir"/></not>
+            <not><available file="${hadoop.dir}" type="dir"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+  <target name="requirepigjar">
+    <fail message="Property &quot;pig.jar&quot; needs to be set to a valid jar file">
+      <condition>
+          <or>
+              <equals arg1="${pig.jar}" arg2=""/>
+              <not><isset property="pig.jar"/></not>
+              <not><available file="${pig.jar}" type="file"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+</project>

--- a/build.xml
+++ b/build.xml
@@ -10,7 +10,7 @@
 
     <property environment="env"/>
 	<condition property="ispig07">
-		<contains string="${pig.version}" substring="0.7"/>
+		<contains string="${pig.jar}" substring="pig-0.7"/>
 	</condition>
 	<target name="executeRecursively">
 		<ant dir="hadoop-connector" target="${action}"/>

--- a/hadoop-connector/build.xml
+++ b/hadoop-connector/build.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="jar" name="hadoop-connector">
+  <include file="../build-common.xml"/>
+
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
@@ -17,7 +19,7 @@
 
 	<property name="build.dir" location="${basedir}/build" />
   <property name="dist" value="${build.dir}/hadoop-connector/jar"/>
-  <property name="jar.file" location="${dist}/${jar.name}.jar" />
+  <property name="jar.file" location="${dist}/${jar.name}-${build.version}.jar" />
 	<property name="build.classes" location="${build.dir}/hadoop-connector/classes"/>
 	<property name="build.test.classes" location="${build.dir}/hadoop-connector/tests" />
     <property name="junit.output.dir" value="${build.dir}/hadoop-connector/junit"/>
@@ -61,19 +63,7 @@
 
     <target depends="clean" name="cleanall"/>
 
-  <target name="requirehadoopdir">
-    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a value">
-      <condition>
-          <or>
-            <equals arg1="${hadoop.dir}" arg2=""/>
-            <not><isset property="hadoop.dir"/></not>
-            <not><available file="${hadoop.dir}" type="dir"/></not>
-         </or>
-     </condition>
-    </fail>
-  </target>
-
-	<target depends="requirehadoopdir,init" name="compile">
+	<target depends="common.requirehadoopdir,init" name="compile">
     <echo>hadoop.dir: ${hadoop.dir}</echo>
     <echo></echo>
 		<mkdir dir="${build.classes}"/>

--- a/hadoop-connector/build.xml
+++ b/hadoop-connector/build.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project basedir="." default="jar" name="hadoop-vertica">
+<project basedir="." default="jar" name="hadoop-connector">
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
 	<property name="vertica.jar" value = "" />
-	<property name="hadoop.dir" value="" />
 	<property name="doc.dir" value="" />
-	<property name="dist" value=""/>
-	
+
 	<property name="jar.name" value="hadoop-vertica" />
     <property name="debuglevel" value="source,lines,vars"/>
 	<property name="javac.source" value="1.6" />
@@ -18,6 +16,8 @@
 	<property name="test.dir" location="${basedir}/test" />
 
 	<property name="build.dir" location="${basedir}/build" />
+  <property name="dist" value="${build.dir}/hadoop-connector/jar"/>
+  <property name="jar.file" location="${dist}/${jar.name}.jar" />
 	<property name="build.classes" location="${build.dir}/hadoop-connector/classes"/>
 	<property name="build.test.classes" location="${build.dir}/hadoop-connector/tests" />
     <property name="junit.output.dir" value="${build.dir}/hadoop-connector/junit"/>
@@ -55,13 +55,27 @@
 
     <target name="clean">
         <delete dir="${build.dir}/hadoop-connector"/>
-        <delete file="${dist}/${jar.name}.jar"/>
+        <delete file="${jar.file}"/>
         <delete dir="${doc.dir}/hadoop-connector"/>
     </target>
 
     <target depends="clean" name="cleanall"/>
-    
-	<target depends="init" name="compile">
+
+  <target name="requirehadoopdir">
+    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a value">
+      <condition>
+          <or>
+            <equals arg1="${hadoop.dir}" arg2=""/>
+            <not><isset property="hadoop.dir"/></not>
+            <not><available file="${hadoop.dir}" type="dir"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+	<target depends="requirehadoopdir,init" name="compile">
+    <echo>hadoop.dir: ${hadoop.dir}</echo>
+    <echo></echo>
 		<mkdir dir="${build.classes}"/>
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" 
@@ -97,7 +111,7 @@
 		</tstamp>        
 		<exec executable="svnversion" outputproperty="svnversion"/>
 		<exec executable="uname" outputproperty="buildsystem"><arg value="-a"/></exec>
-    	<jar jarfile="${dist}/${jar.name}.jar" basedir="${build.classes}">
+    	<jar jarfile="${jar.file}" basedir="${build.classes}">
 			<manifest>
 				<attribute name="Built-By" value="${user.name}"/>
 			    <attribute name="Implementation-Vendor" value="Vertica Systems, Inc."/>

--- a/hadoop-example/build.xml
+++ b/hadoop-example/build.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project basedir="." default="jar" name="hadoop-vertica">
+<project basedir="." default="jar" name="hadoop-example">
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
 	<property name="vertica.jar" value = "" />
+  <property name="hadoop-connector.jar" value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica.jar" />
 	<property name="hadoop.dir" value="" />
-	<property name="dist" value=""/>
 	<property name="doc.dir" value="" />
 	
 	<property name="jar.name" value="hadoop-vertica-example" />
@@ -17,6 +17,8 @@
     <property name="src.dir" location="${basedir}" />
 
 	<property name="build.dir" location="${basedir}/build" />
+  <property name="dist" value="${build.dir}/hadoop-example/jar"/>
+  <property name="jar.file" location="${dist}/${jar.name}.jar" />
 	<property name="build.classes" location="${build.dir}/hadoop-example/" />
 
 	<!-- Lesson: You can add location of jar files here -->
@@ -40,13 +42,25 @@
 
     <target name="clean">
         <delete dir="${build.classes}"/>
-        <delete file="${dist}/${jar.name}.jar"/>
+        <delete file="${jar.file}"/>
         <delete dir="${doc.dir}/hadoop-examples"/>
     </target>
 
     <target depends="clean" name="cleanall"/>
     
-	<target depends="init" name="compile">
+  <target name="requirehadoopdir">
+    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a valid directory">
+      <condition>
+          <or>
+              <equals arg1="${hadoop.dir}" arg2=""/>
+              <not><isset property="hadoop.dir"/></not>
+              <not><available file="${hadoop.dir}" type="dir"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+	<target depends="requirehadoopdir,init" name="compile">
 		<mkdir dir="${build.classes}"/>
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" 
@@ -71,8 +85,9 @@
 	    	<format property="builtat" pattern="yyyy-MM-dd HH:mm:ss Z" timezone="America/New_York"/>
 		</tstamp>        
 		<exec executable="svnversion" outputproperty="svnversion"/>
-		<exec executable="uname" outputproperty="buildsystem"><arg value="-a"/></exec>
-    	<jar jarfile="${dist}/${jar.name}.jar" basedir="${build.classes}">
+    <delete file="${jar.file}"/>
+    <exec executable="uname" outputproperty="buildsystem"><arg value="-a"/></exec>
+    	<jar jarfile="${jar.file}" basedir="${build.classes}">
 			<manifest>
 				<attribute name="Built-By" value="${user.name}"/>
 			    <attribute name="Implementation-Vendor" value="Vertica Systems, Inc."/>

--- a/hadoop-example/build.xml
+++ b/hadoop-example/build.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="jar" name="hadoop-example">
+  <include file="../build-common.xml"/>
+
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
 	<property name="vertica.jar" value = "" />
-  <property name="hadoop-connector.jar" value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica.jar" />
 	<property name="hadoop.dir" value="" />
 	<property name="doc.dir" value="" />
 	
@@ -18,7 +19,7 @@
 
 	<property name="build.dir" location="${basedir}/build" />
   <property name="dist" value="${build.dir}/hadoop-example/jar"/>
-  <property name="jar.file" location="${dist}/${jar.name}.jar" />
+  <property name="jar.file" location="${dist}/${jar.name}-${build.version}.jar" />
 	<property name="build.classes" location="${build.dir}/hadoop-example/" />
 
 	<!-- Lesson: You can add location of jar files here -->
@@ -48,19 +49,7 @@
 
     <target depends="clean" name="cleanall"/>
     
-  <target name="requirehadoopdir">
-    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a valid directory">
-      <condition>
-          <or>
-              <equals arg1="${hadoop.dir}" arg2=""/>
-              <not><isset property="hadoop.dir"/></not>
-              <not><available file="${hadoop.dir}" type="dir"/></not>
-         </or>
-     </condition>
-    </fail>
-  </target>
-
-	<target depends="requirehadoopdir,init" name="compile">
+	<target depends="common.requirehadoopdir,init" name="compile">
 		<mkdir dir="${build.classes}"/>
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" 

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@
 ###
 # Load the standard make definitions
 ###
-export BUILD_ARGS := -lib ${HADOOP_HOME}/ -lib ${PIG_HOME}/lib -Dhadoop.dir=${HADOOP_HOME} -Dbuild.dir=${BUILDDIR} -Ddist=${JAR_DIR} -Dpig.jar=${PIG_HOME}/${PIG_JAR} -Dpig.version="$(pig_version)" -Dvertica.jar=$(VERTICA_JAR) -Dhadoop-connector.jar=$(JAR_DIR)/hadoop-vertica.jar -Dpig-connector.jar=$(JAR_DIR)/pig-vertica.jar -Ddoc.dir=$(JAR_DIR)/doc/
+export BUILD_ARGS :=-Dhadoop.dir=${HADOOP_HOME} -Dpig.jar=${PIG_JAR}
 
 jar: 
 	JAVA_HOME=${JDK16} ant $(BUILD_ARGS) jar

--- a/pig-connector/build.xml
+++ b/pig-connector/build.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="jar" name="pig-vertica">
+  <include file="../build-common.xml"/>
+
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
 	<property name="vertica.jar" value = "" />
-	<property name="hadoop-connector.jar" value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica.jar" />
 	<property name="doc.dir" value="" />
 	
 	<property name="jar.name" value="pig-vertica" />
@@ -17,7 +18,7 @@
 
 	<property name="build.dir" location="${basedir}/build" />
   <property name="dist" value="${build.dir}/pig-connector/jar"/>
-  <property name="jar.file" location="${dist}/${jar.name}.jar" />
+  <property name="jar.file" location="${dist}/${jar.name}-${build.version}.jar" />
 	<property name="build.classes" location="${build.dir}/pig-connector/classes"/>
 
 	<!-- Lesson: You can add location of jar files here -->
@@ -49,32 +50,7 @@
         <delete dir="${doc.dir}/pig-connector"/>
     </target>
 
-
-  <target name="requirehadoopdir">
-    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a valid directory">
-      <condition>
-          <or>
-              <equals arg1="${hadoop.dir}" arg2=""/>
-              <not><isset property="hadoop.dir"/></not>
-              <not><available file="${hadoop.dir}" type="dir"/></not>
-         </or>
-     </condition>
-    </fail>
-  </target>
-
-  <target name="requirepigjar">
-    <fail message="Property &quot;pig.jar&quot; needs to be set to a valid jar file">
-      <condition>
-          <or>
-              <equals arg1="${pig.jar}" arg2=""/>
-              <not><isset property="pig.jar"/></not>
-              <not><available file="${pig.jar}" type="file"/></not>
-         </or>
-     </condition>
-    </fail>
-  </target>
-
-	<target depends="requirehadoopdir, requirepigjar, init" name="compile">
+	<target depends="common.requirehadoopdir,common.requirepigjar,init" name="compile">
     <fail unless="hadoop.dir">Property hadoop.dir must be set.</fail>
     <fail unless="pig.jar">Property pig.jar must be set.</fail>
     <echo>hadoop.dir          : ${hadoop.dir}</echo>

--- a/pig-connector/build.xml
+++ b/pig-connector/build.xml
@@ -4,10 +4,7 @@
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
 	<property name="vertica.jar" value = "" />
-	<property name="hadoop-connector.jar" value = "" />
-	<property name="hadoop.dir" value="" />
-	<property name="pig.jar" value="" />
-	<property name="dist" value=""/>
+	<property name="hadoop-connector.jar" value = "${basedir}/../hadoop-connector/build/hadoop-connector/jar/hadoop-vertica.jar" />
 	<property name="doc.dir" value="" />
 	
 	<property name="jar.name" value="pig-vertica" />
@@ -19,6 +16,8 @@
     <property name="src.dir" location="${basedir}" />
 
 	<property name="build.dir" location="${basedir}/build" />
+  <property name="dist" value="${build.dir}/pig-connector/jar"/>
+  <property name="jar.file" location="${dist}/${jar.name}.jar" />
 	<property name="build.classes" location="${build.dir}/pig-connector/classes"/>
 
 	<!-- Lesson: You can add location of jar files here -->
@@ -46,11 +45,42 @@
 
     <target name="clean">
         <delete dir="${build.dir}/pig-connector"/>
-        <delete file="${dist}/${jar.name}.jar"/>
+        <delete file="${jar.file}"/>
         <delete dir="${doc.dir}/pig-connector"/>
     </target>
 
-	<target depends="init" name="compile">
+
+  <target name="requirehadoopdir">
+    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a valid directory">
+      <condition>
+          <or>
+              <equals arg1="${hadoop.dir}" arg2=""/>
+              <not><isset property="hadoop.dir"/></not>
+              <not><available file="${hadoop.dir}" type="dir"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+  <target name="requirepigjar">
+    <fail message="Property &quot;pig.jar&quot; needs to be set to a valid jar file">
+      <condition>
+          <or>
+              <equals arg1="${pig.jar}" arg2=""/>
+              <not><isset property="pig.jar"/></not>
+              <not><available file="${pig.jar}" type="file"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+	<target depends="requirehadoopdir, requirepigjar, init" name="compile">
+    <fail unless="hadoop.dir">Property hadoop.dir must be set.</fail>
+    <fail unless="pig.jar">Property pig.jar must be set.</fail>
+    <echo>hadoop.dir          : ${hadoop.dir}</echo>
+    <echo>pig.jar             : ${pig.jar}</echo>
+    <echo>hadoop-connector.jar: ${hadoop-connector.jar}</echo>
+    <echo></echo>
 		<mkdir dir="${build.classes}"/>
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" 
@@ -78,7 +108,7 @@
 		</tstamp>        
 		<exec executable="svnversion" outputproperty="svnversion"/>
 		<exec executable="uname" outputproperty="buildsystem"><arg value="-a"/></exec>
-    	<jar jarfile="${dist}/${jar.name}.jar" basedir="${build.classes}">
+    	<jar jarfile="${jar.file}" basedir="${build.classes}">
 			<zipfileset src="${hadoop-connector.jar}"/>
 			<manifest>
 				<attribute name="Built-By" value="${user.name}"/>

--- a/squeal/build.xml
+++ b/squeal/build.xml
@@ -11,10 +11,8 @@
 	<property name="vertica.jar" value = "" />
 	<property name="hadoop-connector.jar" value = "" />
 	<property name="pig-connector.jar" value = "" />
-	<property name="hadoop.dir" value="" />
 	<property name="pig.jar" value="" />
-	<property name="dist" value=""/>
-	
+
 	<property name="jar.name" value="squeal" />
     <property name="debuglevel" value="source,lines,vars"/>
     <property name="target" value="1.6"/>
@@ -25,6 +23,8 @@
 
 	<property name="build.dir" location="${basedir}/build" />
 	<property name="build.classes" location="${build.dir}/squeal/classes"/>
+  <property name="dist" value="${build.dir}/squeal/jar"/>
+  <property name="jar.file" location="${dist}/${jar.name}.jar" />
 
 	<!-- Lesson: You can add location of jar files here -->
     <path id="compile.classpath">
@@ -58,11 +58,37 @@
 
     <target name="clean">
         <delete dir="${build.dir}/squeal"/>
-        <delete file="${dist}/${dest.jar}"/>
+        <delete file="${jar.file}"/>
         <delete dir="${doc.dir}/squeal"/>
     </target>
 
-	<target depends="init" name="compile">
+  <target name="requirehadoopdir">
+    <fail message="Property &quot;hadoop.dir&quot; needs to be set to a value">
+      <condition>
+          <or>
+            <equals arg1="${hadoop.dir}" arg2=""/>
+            <not><isset property="hadoop.dir"/></not>
+            <not><available file="${hadoop.dir}" type="dir"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+  <target name="requirepigjar">
+    <fail message="Property &quot;pig.jar&quot; needs to be set to a valid jar file">
+      <condition>
+          <or>
+              <equals arg1="${pig.jar}" arg2=""/>
+              <not><isset property="pig.jar"/></not>
+              <not><available file="${pig.jar}" type="file"/></not>
+         </or>
+     </condition>
+    </fail>
+  </target>
+
+	<target depends="requirehadoopdir,requirepigjar,init" name="compile">
+    <echo>hadoop.dir          : ${hadoop.dir}</echo>
+    <echo>pig.jar             : ${pig.jar}</echo>
 		<mkdir dir="${build.classes}"/>
         <echo message="${ant.project.name}: ${ant.file}"/>
         <javac debug="true" debuglevel="${debuglevel}" destdir="${build.classes}" source="${source}" target="${target}">
@@ -87,7 +113,7 @@
 		</tstamp>        
 		<exec executable="svnversion" outputproperty="svnversion"/>
 		<exec executable="uname" outputproperty="buildsystem"><arg value="-a"/></exec>
-    	<jar jarfile="${dist}/${jar.name}.jar" basedir="${build.classes}">
+    	<jar jarfile="${jar.file}" basedir="${build.classes}">
 			<zipfileset src="${hadoop-connector.jar}"/>
 			<zipfileset src="${pig-connector.jar}"/>
 			<zipfileset src="${pig.jar}"/>

--- a/squeal/build.xml
+++ b/squeal/build.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project basedir="." default="jar" name="squeal">
+  <include file="../build-common.xml"/>
+
     <property environment="env"/>
 	<!--Required parameters. You have to specify these on the ANT command line -->
 	<!--JUNIT jars should be in the lib path. For e.g. specify using -lib -->
@@ -24,7 +26,7 @@
 	<property name="build.dir" location="${basedir}/build" />
 	<property name="build.classes" location="${build.dir}/squeal/classes"/>
   <property name="dist" value="${build.dir}/squeal/jar"/>
-  <property name="jar.file" location="${dist}/${jar.name}.jar" />
+  <property name="jar.file" location="${dist}/${jar.name}-${build.version}.jar" />
 
 	<!-- Lesson: You can add location of jar files here -->
     <path id="compile.classpath">
@@ -74,19 +76,7 @@
     </fail>
   </target>
 
-  <target name="requirepigjar">
-    <fail message="Property &quot;pig.jar&quot; needs to be set to a valid jar file">
-      <condition>
-          <or>
-              <equals arg1="${pig.jar}" arg2=""/>
-              <not><isset property="pig.jar"/></not>
-              <not><available file="${pig.jar}" type="file"/></not>
-         </or>
-     </condition>
-    </fail>
-  </target>
-
-	<target depends="requirehadoopdir,requirepigjar,init" name="compile">
+	<target depends="common.requirehadoopdir,common.requirepigjar,init" name="compile">
     <echo>hadoop.dir          : ${hadoop.dir}</echo>
     <echo>pig.jar             : ${pig.jar}</echo>
 		<mkdir dir="${build.classes}"/>


### PR DESCRIPTION
Getting into the code to work on a possible patch I made some changes to simplify how the build works. You can now build all targets with just two params:

ant -Dhadoop.dir=... -Dpig.dir=... jar

Or similarly from make. The other params now have sensible defaults.

I changed the sub-project to create the jars under their build dir by default, instead of the root directory. I also added error messaging if required params are missing or invalid.
