### PR TITLE
Refactoring to improve per-task transaction isolation.

### DIFF
--- a/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
@@ -1,3 +1,20 @@
+/*
+Copyright 2013, Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package com.vertica.hadoop;
 
 import org.apache.commons.logging.Log;
@@ -19,12 +36,12 @@ import java.sql.SQLException;
  *
  * An instance of this class should be initialized and setConf and setVerticaOutputFormat should be called.
  *
- * Implementors should consider subclassing VerticaTaskOutputCommitter instread of this class.
+ * Implementors should consider subclassing @{link VerticaTaskOutputCommitter} instead of this class.
  */
 public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
   protected final Log log = LogFactory.getLog(getClass());
 
-  private VerticaOutputFormat verticaOutputFormat;
+  private final VerticaOutputFormat verticaOutputFormat;
 
   /**
    * Initializes the OutputCommitter with a handle to the VerticaOutputFormat so the connection can
@@ -55,7 +72,7 @@ public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
   public void setupJob(JobContext jobContext) throws IOException { }
 
   /**
-   * This method is will only be called only once per job upon a final runstate of
+   * This method is will only be called once per job upon a final runstate of
    * {@link org.apache.hadoop.mapreduce.JobStatus.State#SUCCEEDED}. If this method throws an
    * exception the entire job will fail.
    */
@@ -98,8 +115,7 @@ public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
   protected final void sqlCommit(Connection connection) throws IOException {
     try {
       if (connection == null || connection.isClosed()) {
-        log.warn("Database connection not open so not commiting");
-        return;
+        throw new IOException("Trying to commit a connection that is null or closed: " + connection);
       }
     } catch (SQLException e) {
       throw new IOException("Exception calling isClosed on connection", e);
@@ -122,8 +138,7 @@ public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
 
     try {
       if (connection == null || connection.isClosed()) {
-        log.warn("Database connection not open so not rolling back");
-        return;
+        throw new IOException("Trying to rollback a connection that is null or closed: " + connection);
       }
     } catch (SQLException e) {
       throw new IOException("Exception calling isClosed on connection", e);

--- a/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
@@ -1,0 +1,151 @@
+package com.vertica.hadoop;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Abstract OutputCommitter to extend when implementing a custom OutputCommitter. Contains empty
+ * implementations of methods to allow easy overriding of specific behavior, as well as some common
+ * SQL lifecycle methods.
+ *
+ * An instance of this class should be initialized and setConf and setVerticaOutputFormat should be called.
+ *
+ * Implementors should consider subclassing VerticaTaskOutputCommitter instread of this class.
+ */
+public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
+  protected final Log log = LogFactory.getLog(getClass());
+
+  private VerticaOutputFormat verticaOutputFormat;
+
+  /**
+   * Initializes the OutputCommitter with a handle to the VerticaOutputFormat so the connection can
+   * be lazy-initialized on demand. Custom subclasses configured for a job will be initialized via
+   * reflection using this constructor.
+   *
+   * @param verticaOutputFormat the VerticaOutputFormat object
+   */
+  public AbstractVerticaOutputCommitter(VerticaOutputFormat verticaOutputFormat) {
+    if (verticaOutputFormat == null) {
+      throw new IllegalArgumentException("VerticaOutputFormat must not be null");
+    }
+    this.verticaOutputFormat = verticaOutputFormat;
+  }
+
+  /**
+   * Fetches and returns the connection from the VerticaOutputFormat. The connection will be lazily
+   * opened and cached.
+   * @param configuration the configuraton to use for the connection
+   * @return connection object
+   * @throws IOException if the connection couldn't be fetched
+   */
+  protected Connection getConnection(Configuration configuration) throws IOException {
+    return verticaOutputFormat.getConnection(configuration);
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException { }
+
+  /**
+   * This method is will only be called only once per job upon a final runstate of
+   * {@link org.apache.hadoop.mapreduce.JobStatus.State#SUCCEEDED}. If this method throws an
+   * exception the entire job will fail.
+   */
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException { }
+
+  /**
+   * This method will be called for a final runstate of
+   * {@link org.apache.hadoop.mapreduce.JobStatus.State#FAILED} or
+   * {@link org.apache.hadoop.mapreduce.JobStatus.State#KILLED} and might be called more than once.
+   */
+  @Override
+  public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException { }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException { }
+
+  /**
+   * This method is called upon successful task execution. From the {@link OutputCommitter} javadocs,
+   * under very rare circumstances this may be called multiple times for the same task, but for
+   * different task attempts.
+   */
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException { }
+
+  /**
+   * This method is called upon aborted task execution. This may be called multiple times for the
+   * same task, but for different task attempts.
+   */
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException { }
+
+
+  // Final helper method below.
+
+  /**
+   * Commits and closes the connection if the connection is non-null and open.
+   * @throws IOException if either isClosed or commit fails.
+   */
+  protected final void sqlCommit(Connection connection) throws IOException {
+    try {
+      if (connection == null || connection.isClosed()) {
+        log.warn("Database connection not open so not commiting");
+        return;
+      }
+    } catch (SQLException e) {
+      throw new IOException("Exception calling isClosed on connection", e);
+    }
+
+    try {
+      connection.commit();
+    } catch (SQLException e) {
+      throw new IOException("Exception committing connection", e);
+    } finally {
+      sqlClose(connection);
+    }
+  }
+
+  /**
+   * Rolls back and closes the connection if the connection is non-null and open.
+   * @throws IOException if either isClosed or rollback fails.
+   */
+  protected final void sqlRollback(Connection connection) throws IOException {
+
+    try {
+      if (connection == null || connection.isClosed()) {
+        log.warn("Database connection not open so not rolling back");
+        return;
+      }
+    } catch (SQLException e) {
+      throw new IOException("Exception calling isClosed on connection", e);
+    }
+
+    try {
+      connection.rollback();
+    } catch (SQLException e) {
+      throw new IOException("Exception rolling back connection on table", e);
+    } finally {
+      sqlClose(connection);
+    }
+  }
+
+  /**
+   * Closes the connection
+   */
+  protected final void sqlClose(Connection connection) {
+    try {
+      connection.close();
+    } catch (SQLException e) {
+      log.warn("Exception closing database connection", e);
+    }
+  }
+}

--- a/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/AbstractVerticaOutputCommitter.java
@@ -34,9 +34,7 @@ import java.sql.SQLException;
  * implementations of methods to allow easy overriding of specific behavior, as well as some common
  * SQL lifecycle methods.
  *
- * An instance of this class should be initialized and setConf and setVerticaOutputFormat should be called.
- *
- * Implementors should consider subclassing @{link VerticaTaskOutputCommitter} instead of this class.
+ * Implementers should consider subclassing @{link VerticaTaskOutputCommitter} instead of this class.
  */
 public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
   protected final Log log = LogFactory.getLog(getClass());
@@ -106,7 +104,7 @@ public abstract class AbstractVerticaOutputCommitter extends OutputCommitter {
   public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException { }
 
 
-  // Final helper method below.
+  // Final helper methods below.
 
   /**
    * Commits and closes the connection if the connection is non-null and open.

--- a/hadoop-connector/com/vertica/hadoop/VerticaConfiguration.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaConfiguration.java
@@ -113,6 +113,11 @@ public class VerticaConfiguration {
 	/** Optional output format terminator */
 	public static final String OUTPUT_TERMINATOR_PROP = "mapred.vertica.output.terminator";
 
+  /** Optional override of the default OutputCommitter implementation */
+  public static final String OUTPUT_COMMITTER_CLASS_PARAM = "mapred.vertica.output.committer";
+
+  public static final String DEFAULT_OUTPUT_COMMITTER = VerticaTaskOutputCommitter.class.getCanonicalName();
+
 	/**
 	 * Override the sleep timer for optimize to poll when new projections have
 	 * refreshed
@@ -305,9 +310,15 @@ public class VerticaConfiguration {
 		if (port == null)
 			throw new IOException("Vertica requires a port defined by "
 					+ PORT_PROP);
-		return DriverManager.getConnection("jdbc:vertica://"
+		Connection connection = DriverManager.getConnection("jdbc:vertica://"
 				+ hosts[r.nextInt(hosts.length)] + ":" + port + "/" + database, 
 				 user, pass);
+
+    if (output) {
+      connection.setAutoCommit(false);
+    }
+
+    return connection;
 	}
 
 	public String getInputQuery() {
@@ -376,7 +387,7 @@ public class VerticaConfiguration {
 	 * Sets a collection of lists. Each list is passed to an input split and used
 	 * as arguments to the input query.
 	 * 
-	 * @param segmentParams
+	 * @param segment_params
 	 * @throws IOException
 	*/
 	public void setInputParams(Collection<List<Object>> segment_params)
@@ -464,7 +475,7 @@ public class VerticaConfiguration {
 	/**
 	 * Set the definition of a table for output if it needs to be created
 	 * 
-	 * @param fieldNames
+	 * @param args
 	 */
 	public void setOutputTableDef(String... args) {
 		if(args == null || args.length == 0 || Arrays.asList(args).contains(null)) return;
@@ -526,6 +537,15 @@ public class VerticaConfiguration {
 	public String getOutputRecordTerminator() {
 		return conf.get(OUTPUT_TERMINATOR_PROP, RECORD_TERMINATOR);
 	}
+
+  /**
+   * Return the output committer that the job should use
+   * @return the output committer class to use
+   * @throws ClassNotFoundException if the output committer can't be found
+   */
+  public Class getOutputCommitterClass() throws ClassNotFoundException {
+    return Class.forName(conf.get(OUTPUT_COMMITTER_CLASS_PARAM, DEFAULT_OUTPUT_COMMITTER));
+  }
 
 	/**
 	 * @deprecated  As of release 1.5, this function is not called from the Java API.

--- a/hadoop-connector/com/vertica/hadoop/VerticaConfiguration.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaConfiguration.java
@@ -1,5 +1,22 @@
-/* Copyright (c) 2005 - 2012 Vertica, an HP company -*- Java -*- */
+/*
+Copyright (c) 2005 - 2012 Vertica, an HP company -*- Java -*-
+Copyright 2013, Twitter, Inc.
 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package com.vertica.hadoop;
 
 import java.io.IOException;
@@ -314,6 +331,9 @@ public class VerticaConfiguration {
 				+ hosts[r.nextInt(hosts.length)] + ":" + port + "/" + database, 
 				 user, pass);
 
+    // if output is being written auto-commit must be disabled to prevent individual batches within
+    // a task from being committed. Instead we want all the batches in a task to be committed or
+    // rolled back upon task success or failure
     if (output) {
       connection.setAutoCommit(false);
     }
@@ -349,12 +369,12 @@ public class VerticaConfiguration {
 
 	/**
 	 * Query used to retrieve parameters for the input query. The result set must
-	 * match the input query parameters preceisely.
+	 * match the input query parameters precisely.
 	 * 
-	 * @param segment_params_query
+	 * @param segmentParamsQuery
 	 */
-	public void setParamsQuery(String segment_params_query) {
-		conf.set(QUERY_PARAM_PROP, segment_params_query);
+	public void setParamsQuery(String segmentParamsQuery) {
+		conf.set(QUERY_PARAM_PROP, segmentParamsQuery);
 	}
 
 	/**
@@ -539,7 +559,8 @@ public class VerticaConfiguration {
 	}
 
   /**
-   * Return the output committer that the job should use
+   * Return the output committer that the job should use. Note that the class specified and its
+   * dependencies must be in the classpath of both the submitted job and the tasks on the cluster.
    * @return the output committer class to use
    * @throws ClassNotFoundException if the output committer can't be found
    */

--- a/hadoop-connector/com/vertica/hadoop/VerticaRecordWriter.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaRecordWriter.java
@@ -1,5 +1,22 @@
-/* Copyright (c) 2005 - 2012 Vertica, an HP company -*- Java -*- */
+/*
+Copyright (c) 2005 - 2012 Vertica, an HP company -*- Java -*-
+Copyright 2013, Twitter, Inc.
 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package com.vertica.hadoop;
 
 import java.io.IOException;
@@ -78,7 +95,7 @@ public class VerticaRecordWriter extends RecordWriter<Text, VerticaRecord> {
       // committing and closing the connection is handled by the VerticaTaskOutputCommitter
       if (LOG.isDebugEnabled()) { LOG.debug("executeBatch called during close"); }
 			statement.executeBatch();
-		} catch (Exception e) {
+  } catch (SQLException e) {
 			throw new IOException(e);
 		}
 	}

--- a/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
@@ -1,3 +1,20 @@
+/*
+Copyright 2013, Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package com.vertica.hadoop;
 
 import org.apache.hadoop.mapreduce.OutputCommitter;

--- a/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 /**
  * Class that knows how to commit or rollback SQL connections at the task level. This class can be
  * subclassed to handle specific commit/rollback actions upon job completion.
- * @see VerticaConfiguration.
  */
 public class VerticaTaskOutputCommitter extends AbstractVerticaOutputCommitter {
 

--- a/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaTaskOutputCommitter.java
@@ -1,0 +1,44 @@
+package com.vertica.hadoop;
+
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * Class that knows how to commit or rollback SQL connections at the task level. This class can be
+ * subclassed to handle specific commit/rollback actions upon job completion.
+ * @see VerticaConfiguration.
+ */
+public class VerticaTaskOutputCommitter extends AbstractVerticaOutputCommitter {
+
+  public VerticaTaskOutputCommitter(VerticaOutputFormat verticaOutputFormat) {
+    super(verticaOutputFormat);
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+    return true;
+  }
+
+  /**
+   * This method is called upon successful task execution. From the {@link OutputCommitter} javadocs,
+   * under very rare circumstances this may be called multiple times for the same task, but for
+   * different task attempts.
+   */
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    log.info("Task complete - committing database connection");
+    sqlCommit(getConnection(taskAttemptContext.getConfiguration()));
+  }
+
+  /**
+   * This method is called upon aborted task execution. This may be called multiple times for the
+   * same task, but for different task attempts.
+   */
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+    log.warn("Task aborted - rolling back database connection");
+    sqlRollback(getConnection(taskAttemptContext.getConfiguration()));
+  }
+}


### PR DESCRIPTION
This fixes existing bugs that cause duplicates when tasks die or are killed:
- Each executeBatch in a task is currently committed individually
- Currently the connection is implicitly committed during VerticaOutputFormat.close() which occurs during task kill

The fix includes:
- Setting autoCommit to false
- Handling commits and rollback in a new VerticaTaskOutputCommitter
- Adding ability to plug in a custom committer via mapred.vertica.output.committer. We plan to extend VerticaTaskOutputCommitter to implement custom table verification (and potentially manual rollback) in commitJob.
