### PR TITLE
VerticaRecord get(String name) function

### DIFF
--- a/hadoop-connector/com/vertica/hadoop/VerticaRecord.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaRecord.java
@@ -177,8 +177,8 @@ public class VerticaRecord implements Writable {
 
 		for (int i = 1; i <= columns; i++) {
 			LOG.debug("Inserting " + meta.getCatalogName(i) + ":" + meta.getColumnType(i) + ":" + meta.getColumnTypeName(i) + " at " + i);
-			names.add(meta.getCatalogName(i));
-			nameMap.put(meta.getCatalogName(i),i-1);
+			names.add(meta.getColumnName(i));
+			nameMap.put(meta.getColumnName(i),i-1);
 //			if (meta.getColumnType(i) == 1111)
 //				types.add(VerticaDayTimeInterval.INTERVAL_DAY_TO_SECOND);
 //			else


### PR DESCRIPTION
VerticaInputFormat that is used to read data from Vertica from within a Hadoop application generates VerticaRecord class out of the query resultset. 
VerticaRecord has capability to fetch result from resultset based on column index but not column names.
Modified the code to provide flexibility to fetch result from column name as well.
