### PR TITLE
Changed behavior to use DatabaseMetaData.getSchemas() for validaton of o...

### DIFF
--- a/hadoop-connector/com/vertica/hadoop/VerticaOutputFormat.java
+++ b/hadoop-connector/com/vertica/hadoop/VerticaOutputFormat.java
@@ -113,6 +113,9 @@ public class VerticaOutputFormat extends OutputFormat<Text, VerticaRecord> {
 			DatabaseMetaData dbmd = conn.getMetaData();
 			ResultSet rs = dbmd.getTables(null, vTable.getSchema(), vTable.getTable(), null);
 			boolean tableExists = rs.next();
+			
+			rs = dbmd.getSchemas(null, vTable.getSchema());
+			boolean schemaExists = rs.next();
 
 			stmt = conn.createStatement();
 
@@ -126,8 +129,13 @@ public class VerticaOutputFormat extends OutputFormat<Text, VerticaRecord> {
 				if (def == null)
 					throw new RuntimeException("Table " + vTable.getQualifiedName().toString()
 							+ " does not exist and no table definition provided");
-				if (!vTable.isDefaultSchema()) {
-					stmt.execute("CREATE SCHEMA IF NOT EXISTS " + vTable.getSchema());
+				if (!vTable.isDefaultSchema() && !schemaExists) {
+					try {
+					stmt.execute("CREATE SCHEMA " + vTable.getSchema());
+					}
+					catch(SQLException e) {
+						throw new RuntimeException("Exception caught while creating schema.", e);
+					}
 				}
 				StringBuffer tabledef = new StringBuffer("CREATE TABLE ").append(
 						vTable.getQualifiedName().toString()).append(" (");


### PR DESCRIPTION
...utput schema existence.

The connector will only execute CREATE SCHEMA if it has determined through the DatabaseMetaData that the schema does not already exist.

This enhancement makes it possible for less privileged accounts to create tables on-demand in their own schema, but without requiring CREATE privileges at the database level. 

This is useful in an enterprise environment, where it is common for a shared services team to provision a schema to a customer, but limit their CREATE privileges to the schema only.
